### PR TITLE
[workflow] Fix typo in branch name

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -3,13 +3,13 @@ name: Build Application
 on: 
     workflow_dispatch:
     pull_request:
-      branches: [ main ]
+      branches: [ master ]
       paths:
         - '**/*.gradle'
         - 'app/src/**'
         - '.github/workflows/build-app.yml'
     push:
-      branches: [ main ]
+      branches: [ master ]
       paths:
         - '**/*.gradle'
         - 'app/src/**'


### PR DESCRIPTION
Fix for mistyping the branch name as 'main'